### PR TITLE
Require acceptance of privacy policy

### DIFF
--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -1,18 +1,21 @@
-export type Rule = (v: string) => boolean | string;
+type RuleResult = boolean | string;
+export type Rule<T> = (v: T) => RuleResult;
 
-export const nameRules: Rule[] = [
-  v => !!v || "Name is required"
+export const nameRules: Rule<string>[] = [
+  (v: string): RuleResult => !!v || "Name is required"
 ];
 
-export const usernameRules: Rule[] = [
-  v => !!v || "Username is required"
+export const usernameRules: Rule<string>[] = [
+  (v: string): RuleResult => !!v || "Username is required"
 ];
 
-export const emailRules: Rule[] = [
-  v => !!v || "Email is required",
-  v => /.+@.+\..+/.test(v) || "E-mail must be valid",
+export const emailRules: Rule<string>[] = [
+  (v: string): RuleResult => !!v || "Email is required",
+  (v: string): RuleResult => /.+@.+\..+/.test(v) || "E-mail must be valid",
 ];
 
-export const passwordRules: Rule[] = [
-  v => !!v || "Password is required"
+export const passwordRules: Rule<string>[] = [
+  (v: string): RuleResult => !!v || "Password is required"
 ];
+
+export const checkboxTrueRule: Rule<boolean> = v => !!v || "You must agree to continue";

--- a/src/views/CreateEducatorAccount.vue
+++ b/src/views/CreateEducatorAccount.vue
@@ -60,6 +60,16 @@
             :items="['Male', 'Female', 'Other']"
             label="Gender"
           ></v-select>
+          <v-checkbox
+            :rules="[checkboxTrueRule]"
+            required
+          >
+            <template v-slot:label>
+              <div>
+                I agree to <a target="_blank" href="https://www.cfa.harvard.edu/privacy-statement" @click.stop>this privacy policy</a>
+              </div>
+            </template>
+          </v-checkbox>
           <v-alert
             v-if="errorMessage"
             color="red lighten-2"
@@ -82,7 +92,7 @@
 
 <script lang="ts">
 import { Component } from "vue-property-decorator";
-import { emailRules, nameRules, passwordRules } from "@/utils/rules";
+import { checkboxTrueRule, emailRules, nameRules, passwordRules } from "@/utils/rules";
 import FormBase from "@/components/FormBase.vue";
 import { mapActions } from "vuex";
 
@@ -102,10 +112,11 @@ export default class CreateEducatorAccount extends FormBase {
   age = 33;
   gender = "Male";
 
-  valid = true;
+  valid = false;
   nameRules = nameRules;
   emailRules = emailRules;
   passwordRules = passwordRules;
+  checkboxTrueRule = checkboxTrueRule;
 
   errorMessage = "";
   successMessage = "";

--- a/src/views/CreateStudentAccount.vue
+++ b/src/views/CreateStudentAccount.vue
@@ -53,6 +53,16 @@
             v-model="classroomCode"
             label="Classroom Code"
           ></v-text-field>
+          <v-checkbox
+            :rules="[checkboxTrueRule]"
+            required
+          >
+            <template v-slot:label>
+              <div>
+                I agree to <a target="_blank" href="https://www.cfa.harvard.edu/privacy-statement" @click.stop>this privacy policy</a>
+              </div>
+            </template>
+          </v-checkbox>
           <v-alert
             v-if="errorMessage"
             color="red lighten-2"
@@ -75,7 +85,7 @@
 
 <script lang="ts">
 import { Component } from "vue-property-decorator";
-import { emailRules, nameRules, passwordRules, usernameRules } from "@/utils/rules";
+import { checkboxTrueRule, emailRules, nameRules, passwordRules, usernameRules } from "@/utils/rules";
 import FormBase from "@/components/FormBase.vue";
 import { mapActions } from "vuex";
 
@@ -89,7 +99,7 @@ export default class CreateStudentAccount extends FormBase {
 
   username = "TestStudent";
   classroomCode = "";
-  valid = true;
+  valid = false;
   email = "teststudent@testschool.edu";
   password = "testpass";
   institution = "TestSchool";
@@ -99,6 +109,7 @@ export default class CreateStudentAccount extends FormBase {
   emailRules = emailRules;
   passwordRules = passwordRules;
   usernameRules = usernameRules;
+  checkboxTrueRule = checkboxTrueRule;
 
   errorMessage = "";
   successMessage = "";
@@ -119,6 +130,7 @@ export default class CreateStudentAccount extends FormBase {
   }
 
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async submit(): Promise<any> {
     return this.submitStudentSignUp({
       username: this.username,

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -106,7 +106,7 @@ export default class Login extends FormBase {
     return this.submitLogin({ email: this.email, password: this.password });
   }
 
-  responseErrorMessage(response: LoginResponse) {
+  responseErrorMessage(response: LoginResponse): string {
     switch (response.result) {
       case "email_not_exist":
         return `No ${this.loginType} account with this email exists`;


### PR DESCRIPTION
This PR requires students and educators to accept the CfA privacy when creating their accounts. This is done via a checkbox in the account creation form which needs to be checked for the form to validate.